### PR TITLE
Added Gezebo 9 workaround for the REST error fetching from ignition API

### DIFF
--- a/scripts/config.yaml
+++ b/scripts/config.yaml
@@ -1,0 +1,6 @@
+---
+# The list of servers.
+servers:
+  -
+    name: osrf
+    url: https://fuel.ignitionrobotics.org

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+IGNITION_ROOT=~/.ignition/fuel
+
+mkdir -p "$IGNITION_ROOT"
+
+if [ ! -f "$IGNITION_ROOT/config.yaml" ]; then
+    cp config.yaml "$IGNITION_ROOT/"
+fi
+
 if_is_link=`readlink $0`
 command_name=$0
 if [[ if_is_link ]]; then


### PR DESCRIPTION
Seems like there's a bug in Gazebo 9, described [here](https://github.com/osrf/gazebo/issues/2607). There's a workaround suggesting to change URL in the igntition config. As it's absent during initial run, we can just automatically create required directories and copy a default config with a patched URL there.

Fixes #8 